### PR TITLE
Adding preconnect tags to speed up connections

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/all.min.css" />


### PR DESCRIPTION
I'm adding `<link rel="preconnect"...`> to some external dependencies (fonts.google.com and cdnjs.cloudflare.com) to speed up connections.

See more on [web.dev](https://web.dev/preconnect-and-dns-prefetch/)

Closes #29 