### PR TITLE
Issue No. #49 [BUG FIXED] In the footer section, the copyright year should be dynamically generated instead of being statically hardcoded.

### DIFF
--- a/copyrightYear.js
+++ b/copyrightYear.js
@@ -1,0 +1,4 @@
+let copyRightYear = document.getElementById("copyright-year");
+let currentDate = new Date();
+let currentYear = currentDate.getFullYear();
+copyRightYear.innerText = currentYear;

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
 
   <!-- for footer -->
   <footer class="footer2">
-    <p>Copyright © 2022 All Rights Reserved & Developed by Samrat Ghosh</p>
+    <p>Copyright © <span id="copyright-year"></span> Rights Reserved & Developed by Samrat Ghosh</p>
   </footer>
   <script>
     const hamburger = document.getElementById("hamburger");
@@ -106,6 +106,9 @@
     });
   </script>
   <script src="script.js"></script>
+
+  <!-- Copyright Year --- -->
+  <script src="./copyrightYear.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Closes #49 